### PR TITLE
removing redis password

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -79,11 +79,6 @@ objects:
                     secretKeyRef:
                       name: ${REDIS_SECRET_NAME}
                       key: db.port
-                - name: REDIS_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${REDIS_SECRET_NAME}
-                      key: db.auth_token
                 - name: DATABASE_HOST
                   valueFrom:
                     secretKeyRef:
@@ -159,11 +154,6 @@ objects:
                     secretKeyRef:
                       name: ${REDIS_SECRET_NAME}
                       key: db.port
-                - name: REDIS_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${REDIS_SECRET_NAME}
-                      key: db.auth_token
                 - name: DATABASE_HOST
                   valueFrom:
                     secretKeyRef:
@@ -290,11 +280,6 @@ objects:
                     secretKeyRef:
                       name: ${REDIS_SECRET_NAME}
                       key: db.port
-                - name: REDIS_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${REDIS_SECRET_NAME}
-                      key: db.auth_token
                 - name: DATABASE_HOST
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
REDIS Auth Token is not used as a Password in REDIS, Removing