### PR TITLE
added service account for glitchtip-beat

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -21,6 +21,12 @@ objects:
       name: glitchtip-configmap
 
   # ---- BEAT DEPLOYMENT ------
+
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: glitchtip-beat-sa
+
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -32,6 +38,7 @@ objects:
         app.kubernetes.io/name: glitchtip
       name: glitchtip-beat
     spec:
+      serviceAccountName: glitchtip-beat-sa
       progressDeadlineSeconds: 600
       replicas: ${{BEAT_REPLICAS}}
       revisionHistoryLimit: 10
@@ -505,7 +512,7 @@ parameters:
     displayName: BEAT_REPLICAS
     required: true
     name: BEAT_REPLICAS
-    value: "1"
+    value: "3"
 
   - description: GT_WEB_REPLICAS
     displayName: GT_WEB_REPLICAS

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -38,7 +38,6 @@ objects:
         app.kubernetes.io/name: glitchtip
       name: glitchtip-beat
     spec:
-      serviceAccountName: glitchtip-beat-sa
       progressDeadlineSeconds: 600
       replicas: ${{BEAT_REPLICAS}}
       revisionHistoryLimit: 10
@@ -59,6 +58,7 @@ objects:
             app.kubernetes.io/instance: glitchtip
             app.kubernetes.io/name: glitchtip
         spec:
+          serviceAccountName: glitchtip-beat-sa
           containers:
             - env:
                 - name: SERVER_ROLE

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -512,7 +512,7 @@ parameters:
     displayName: BEAT_REPLICAS
     required: true
     name: BEAT_REPLICAS
-    value: "3"
+    value: "1"
 
   - description: GT_WEB_REPLICAS
     displayName: GT_WEB_REPLICAS


### PR DESCRIPTION
Hi @deepak1725, @pepedocs regarding the https://issues.redhat.com/browse/CSSRE-1997: glitchtip-beat pod is using default service account, I've added a `glitchtip-beat-sa` for the deployment, please give it a look

I've also modified the glitchtip-beat replicas to 3, regarding https://issues.redhat.com/browse/CSSRE-2001, minimum three replicas