### PR TITLE
added antiaffinity and topologyKey, reg: CSSRE-2000

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -143,6 +143,16 @@ objects:
           labels:
             glitchtip: web
         spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: glithtip
+                    operator: In
+                    values:
+                    - web
+                topologyKey: "kubernetes.io/hostname"
           initContainers:
             - name: init-migration
               image: "${REGISTRY_IMAGE}:${IMAGE_TAG}"


### PR DESCRIPTION
Hi @deepak1725, @pepedocs ,
this is regarding [CSSRE-2000](https://issues.redhat.com/browse/CSSRE-2000)
remediation from ticket: Specify anti-affinity in your pod specification to ensure that the orchestrator attempts to schedule replicas on different nodes. Using podAntiAffinity, specify a labelSelector that matches pods for the deployment, and set the topologyKey to kubernetes.io/hostname