### PR TITLE
Updating Probes and updating job name

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -394,7 +394,7 @@ objects:
   - apiVersion: batch/v1
     kind: Job
     metadata:
-      name: superuser-job
+      name: superuser-job-1
     spec:
       parallelism: 1
       completions: 1

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -409,31 +409,34 @@ objects:
       backoffLimit: 3
       template:
         metadata:
-          name: superb-job
+          name: superuser-job-1
         spec:
           containers:
-            - name: superb-job
+            - name: superuser-job-co
               image: "${REGISTRY_IMAGE}:${IMAGE_TAG}"
               command:
                 ["python3", "./manage.py", "createsuperuser", "--noinput"]
+              startupProbe:
+                exec:
+                  command:
+                    - touch
+                    - /tmp/healthy
+                initialDelaySeconds: 5
+                periodSeconds: 5
               readinessProbe:
-                httpGet:
-                  path: /
-                  port: ${{GT_APP_PORT}}
-                  httpHeaders:
-                    - name: Test-Header
-                      value: Awesome
-                initialDelaySeconds: 3
-                periodSeconds: 3
+                exec:
+                  command:
+                    - cat
+                    - /tmp/healthy
+                initialDelaySeconds: 5
+                periodSeconds: 5
               livenessProbe:
-                httpGet:
-                  path: /
-                  port: ${{GT_APP_PORT}}
-                  httpHeaders:
-                    - name: Test-Header
-                      value: Awesome
-                initialDelaySeconds: 3
-                periodSeconds: 3
+                exec:
+                  command:
+                    - cat
+                    - /tmp/healthy
+                initialDelaySeconds: 5
+                periodSeconds: 5
               resources:
                 requests:
                   cpu: 1m

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -366,6 +366,13 @@ objects:
                   value: ${GT_APP_PORT}
               image: "${REGISTRY_IMAGE}:${IMAGE_TAG}"
               name: worker
+              startupProbe:
+                exec:
+                  command:
+                    - touch
+                    - /tmp/healthy
+                initialDelaySeconds: 5
+                periodSeconds: 5
               readinessProbe:
                 exec:
                   command:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -366,25 +366,14 @@ objects:
                   value: ${GT_APP_PORT}
               image: "${REGISTRY_IMAGE}:${IMAGE_TAG}"
               name: worker
-              startupProbe:
-                exec:
-                  command:
-                    - touch
-                    - /tmp/healthy
-                initialDelaySeconds: 5
-                periodSeconds: 5
               readinessProbe:
                 exec:
-                  command:
-                    - cat
-                    - /tmp/healthy
+                  command: ["celery", "-A", "glitchtip", "status"]
                 initialDelaySeconds: 5
                 periodSeconds: 5
               livenessProbe:
                 exec:
-                  command:
-                    - cat
-                    - /tmp/healthy
+                  command: ["celery", "-A", "glitchtip", "status"]
                 initialDelaySeconds: 5
                 periodSeconds: 5
               resources:
@@ -412,29 +401,22 @@ objects:
           name: superuser-job-1
         spec:
           containers:
-            - name: superuser-job-co
+            - name: superuser-job-1
               image: "${REGISTRY_IMAGE}:${IMAGE_TAG}"
               command:
                 ["python3", "./manage.py", "createsuperuser", "--noinput"]
-              startupProbe:
-                exec:
-                  command:
-                    - touch
-                    - /tmp/healthy
-                initialDelaySeconds: 5
-                periodSeconds: 5
               readinessProbe:
                 exec:
                   command:
-                    - cat
-                    - /tmp/healthy
+                    - ls
+                    - /tmp/
                 initialDelaySeconds: 5
                 periodSeconds: 5
               livenessProbe:
                 exec:
                   command:
-                    - cat
-                    - /tmp/healthy
+                    - ls
+                    - /tmp/
                 initialDelaySeconds: 5
                 periodSeconds: 5
               resources:


### PR DESCRIPTION
**Updating Probes**: Adding Startup Probe to create a File which would be further probed by Liveness and Readiness.

**Updating Job Name**: Job names are immutable, In the last PR, we added Probes in Job as a Placeholder to silence DVO. 
Since Job is an immutable object, we need to change its name so as `saas-herder` sees this as a new object and our updates get deployed.