### PR TITLE
fixing beat pod crashing on staging env. 

### DIFF
--- a/openshift/kubernetes/README.md
+++ b/openshift/kubernetes/README.md
@@ -18,7 +18,7 @@
 - Create a Admin User Creds, A job will create a Admin account to enable signin in the application:
     > `kubectl create secret generic superuser-secret --from-literal=DJANGO_SUPERUSER_EMAIL=admin@admin.com --from-literal=DJANGO_SUPERUSER_PASSWORD={ANY-BASIC-PASSWORD-THAT-YOU-CAN-REMEMBER} --from-literal=DJANGO_SUPERUSER_USERNAME=admin`
 - Create a Generic Secret:
-    > `kubectl create secret generic glitchtip-secret --from-literal=PASSWORD_HASH_TOKEN="&9+w^zi1r(ii^4fgpw6t=9cdyy5flyv@y=j9vtr@0jj83o(8bd"`
+    > `kubectl create secret generic tokens --from-literal=PASSWORD_SALT_TOKEN="&9+w^zi1r(ii^4fgpw6t=9cdyy5flyv@y=j9vtr@0jj83o(8bd"`
 
 Finally Deploy rest of the artifacts with: `kubectl apply -f k8s.yaml`
 

--- a/openshift/kubernetes/k8s.yaml
+++ b/openshift/kubernetes/k8s.yaml
@@ -62,8 +62,8 @@ spec:
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: glitchtip-secret
-                  key: PASSWORD_HASH_TOKEN
+                  name: tokens
+                  key: PASSWORD_SALT_TOKEN
             - name: REDIS_PORT
               valueFrom:
                 secretKeyRef:
@@ -367,6 +367,7 @@ spec:
   completions: 1
   activeDeadlineSeconds: 1800
   backoffLimit: 3
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: superuser-job-1

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -71,8 +71,8 @@ objects:
                 - name: SECRET_KEY
                   valueFrom:
                     secretKeyRef:
-                      name: glitchtip-secret
-                      key: PASSWORD_HASH_TOKEN
+                      name: tokens
+                      key: PASSWORD_SALT_TOKEN
                 - name: REDIS_PORT
                   valueFrom:
                     secretKeyRef:
@@ -392,7 +392,7 @@ objects:
   - apiVersion: batch/v1
     kind: Job
     metadata:
-      name: superuser-job-1
+      name: superuser-job-2
     spec:
       parallelism: 1
       completions: 1
@@ -401,10 +401,10 @@ objects:
       ttlSecondsAfterFinished: 100
       template:
         metadata:
-          name: superuser-job-1
+          name: superuser-job-2
         spec:
           containers:
-            - name: superuser-job-1
+            - name: superuser-job-2
               image: "${REGISTRY_IMAGE}:${IMAGE_TAG}"
               command:
                 ["python3", "./manage.py", "createsuperuser", "--noinput"]


### PR DESCRIPTION
#### What:
* Beat Pod is Crashing on Staging because the secret is moved and renamed to a different location in Vault.
* Updating the Job name to deploy the spec changes in the staging env. Currently, the Deploy pipeline is raising `Immutable Error`. We believe this would be the last time the name changes are required. Once the new job with spec `ttlSecondsAfterFinished` is deployed successfully, it would be auto-deleted in specified time. 

#### Why:
Secrets placement was streamlined and separated in staging env based on concern. All CI used secrets were put together and Application consumed secrets are separated. This PR is a part of that change. 

JIRA: https://issues.redhat.com/browse/CSSRE-2090 