### PR TITLE
fixing beat container probes 

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -112,23 +112,15 @@ objects:
               imagePullPolicy: Always
               name: glitchtip
               readinessProbe:
-                httpGet:
-                  path: /
-                  port: ${{GT_APP_PORT}}
-                  httpHeaders:
-                    - name: Test-Header
-                      value: Awesome
-                initialDelaySeconds: 3
-                periodSeconds: 3
+                exec:
+                  command: ["ls", "/tmp"]
+                initialDelaySeconds: 30
+                periodSeconds: 5
               livenessProbe:
-                httpGet:
-                  path: /
-                  port: ${{GT_APP_PORT}}
-                  httpHeaders:
-                    - name: Test-Header
-                      value: Awesome
-                initialDelaySeconds: 3
-                periodSeconds: 3
+                exec:
+                  command: ["ls", "/tmp"]
+                initialDelaySeconds: 30
+                periodSeconds: 5
               resources:
                 limits:
                   cpu: ${{BEAT_CPU_LIMITS}}


### PR DESCRIPTION
#### What:
* Fixing Beat Probes

#### Why:
Beat Container doesn't expose any endpoint at `/`, hence Probes (Liveness/Readiness) doesn't not work. 
We tried with `celery status check Probes, that again will not work as celery takes a lot of time to boot up and that particular probe is Network heavy.

- In Preference of simplicity, we are resorting to a simple `ls /tmp` probe
 

#### Tickets:
https://issues.redhat.com/browse/CSSRE-2058 
