### PR TITLE
version change for node due to dependency packages

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: npm ci --force
       - run: npm run test -- --progress false --watch=false --browsers=ChromiumHeadless
 
   lint:
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: npm ci --force
       - run: npm run lint
       # test openshift/template.yaml
       - name: Install oc
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -76,7 +76,7 @@ jobs:
       # check backend server is up
       - run: sleep 60 & nc -vz 127.0.0.1 8000
       # start glitchtip-frontend server
-      - run: npm ci
+      - run: npm ci --force
       - run: npm start & npx wait-on http://localhost:4200
       - run: sleep 30
       - run: npm run cy:run

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
#### What:
we are facing errors in CI for unit-tests due to failed dependency resolution
```
npm ERR! Could not resolve dependency:
npm ERR! peer @angular/common@"^13.0.0" from ngx-markdown@13.1.0
npm ERR! node_modules/ngx-markdown
npm ERR!   ngx-markdown@"^13.1.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: @angular/common@13.3.11
```
this is due to node version we are using which is `16.x`

I've modified the node version to `14.x`
