### PR TITLE
modified gt-web from http to tcp

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -278,21 +278,13 @@ objects:
               ports:
                 - containerPort: ${{GT_APP_PORT}}
               readinessProbe:
-                httpGet:
-                  path: /
+                tcpSocket:
                   port: ${{GT_APP_PORT}}
-                  httpHeaders:
-                    - name: Test-Header
-                      value: Awesome
                 initialDelaySeconds: 10
                 periodSeconds: 15
               livenessProbe:
-                httpGet:
-                  path: /
+                tcpSocket:
                   port: ${{GT_APP_PORT}}
-                  httpHeaders:
-                    - name: Test-Header
-                      value: Awesome
                 initialDelaySeconds: 15
                 periodSeconds: 15
               resources:


### PR DESCRIPTION
testing out if tcp socket works for glitchtip web rather than http. I'm thinking the readiness is not available as the path is not defined in the application
