### PR TITLE
fix incorrect glitchtip url in invite emails

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -444,6 +444,11 @@ objects:
                     secretKeyRef:
                       name: ${SMTP_SETTINGS_SECRET}
                       key: require_tls
+                - name: GLITCHTIP_DOMAIN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: glitchtip-configmap
+                      key: GLITCHTIP_DOMAIN
               image: "${REGISTRY_IMAGE}:${IMAGE_TAG}"
               name: worker
               readinessProbe:


### PR DESCRIPTION
#### What:
<!--- Please include bullet points of the purpose of your code. 
Those points should be concise and describe what you expect to happen. -->
* $TITLE

#### Why:
<!--- Please include the context and background for your change. 
For example, why are you requesting this permission, any 
justification or approval you can provide is helpful. -->

The "join the team" button in the invite email points to localhost:8000
